### PR TITLE
Fixed a bug with color checking

### DIFF
--- a/server/libs/indenticon/indenticon.js
+++ b/server/libs/indenticon/indenticon.js
@@ -46,7 +46,8 @@ class IndentIcon {
     }
 
     static _checkColor(color) {
-        if (!color || !color.red || !color.green || !color.blue) {
+        if (!color || typeof color.red !== 'number' || typeof color.green !== 'number' ||
+            typeof color.blue !== 'number') {
             throw new TypeError('Bad color object');
         }
     }


### PR DESCRIPTION
В общем, есть баг при генерации аватарки. При определённом стечении обстоятельств не генерится, бросает исключение "Bad color object". Например, на мой логин на гитхабе. Потому что проверка идёт по числам и есть 0, который неявно кастуется к false. 